### PR TITLE
Fix table's form saying user is writer when they are not

### DIFF
--- a/client/src/utils/helpers.ts
+++ b/client/src/utils/helpers.ts
@@ -58,7 +58,7 @@ const getPitchTeamsForContributor = (
 
   const contributor = pitch.assignmentContributors.find(isUser)?.teams || [];
 
-  if (user._id === pitch.author._id) {
+  if (user._id === pitch.writer._id) {
     contributor.push(WRITING_TEAM);
   }
 


### PR DESCRIPTION
## Summary

Modifies the Team's You're On columns to only show "Writing" if they are actually the writer, not just the author. 

## Changes

- Change condition that adds Writing to the Team's You're On
