### PR TITLE
Reverse Issues Sorting Order

### DIFF
--- a/client/src/components/form/ReviewClaimForm.tsx
+++ b/client/src/components/form/ReviewClaimForm.tsx
@@ -1,6 +1,6 @@
 import { FastField, Form as FormikForm, Formik, FormikHelpers } from 'formik';
 import { cloneDeep, difference, lowerCase, pick, startCase } from 'lodash';
-import React, { FC, ReactElement, useState } from 'react';
+import React, { FC, ReactElement, useState, useEffect } from 'react';
 import { MultiValue } from 'react-select';
 import { Button, Form, Icon, Label } from 'semantic-ui-react';
 import { BasePopulatedPitch, FullPopulatedPitch, Pitch } from 'ssw-common';
@@ -61,6 +61,13 @@ export const ReviewClaimForm: FC<FormProps> = ({
   const [editMode, setEditMode] = useState<boolean>(false);
   const { getInterestById, interests } = useInterests();
   const { getIssueFromId, issues, fetchIssues } = useIssues();
+
+  useEffect(() => {
+    issues.sort(
+      (a, b) =>
+        new Date(b.releaseDate).getTime() - new Date(a.releaseDate).getTime(),
+    );
+  }, [editMode, issues]);
 
   const handleSave = async (
     data: FormData,

--- a/client/src/components/modal/ReviewPitch.tsx
+++ b/client/src/components/modal/ReviewPitch.tsx
@@ -89,8 +89,12 @@ export const ReviewPitch: FC<ReviewPitchProps> = ({
 
     if (open) {
       loadPitch();
+      issues.sort(
+        (a, b) =>
+          new Date(b.releaseDate).getTime() - new Date(a.releaseDate).getTime(),
+      );
     }
-  }, [open, id, teams]);
+  }, [open, id, teams, issues]);
 
   const approvePitch = async (): Promise<void> => {
     const parsedTeams = Object.entries(teamConfig)

--- a/client/src/pages/Issues.tsx
+++ b/client/src/pages/Issues.tsx
@@ -30,11 +30,11 @@ const Issues = (): ReactElement => {
 
       allIssues.sort(
         (a, b) =>
-          new Date(a.releaseDate).getTime() - new Date(b.releaseDate).getTime(),
+          new Date(b.releaseDate).getTime() - new Date(a.releaseDate).getTime(),
       );
 
       const closestIssueIndex = allIssues.findIndex(
-        (issue) => new Date() <= new Date(issue.releaseDate),
+        (issue) => new Date() >= new Date(issue.releaseDate),
       );
 
       if (closestIssueIndex < 0) {


### PR DESCRIPTION
## Summary

Issues dropdowns should be sorted in reverse order based on their release date on the Issues page, Submit Pitch Modal, Pitch Page, etc. (Anywhere an issue dropdown is used). 

## Changes

Reversed issues sorting order in the following places: 
- Stories > Review New Pitch > Add Pitch to Issue(s)
- Issues (page) 
- Issues > Edit Pitch > Add Pitch to Issue(s)