### PR TITLE
Page and Word Count

### DIFF
--- a/api/src/models/pitch.model.ts
+++ b/api/src/models/pitch.model.ts
@@ -93,6 +93,8 @@ const Pitch = new mongoose.Schema(
       enum: Object.values(editStatusEnum),
       default: editStatusEnum.WRITER_NEEDED,
     },
+    wordCount: { type: Number, default: null },
+    pageCount: { type: Number, default: null },
   },
   { timestamps: true },
 );

--- a/client/src/components/form/ReviewClaimForm.tsx
+++ b/client/src/components/form/ReviewClaimForm.tsx
@@ -254,26 +254,40 @@ export const ReviewClaimForm: FC<FormProps> = ({
 
             <div className="row">
               <div className="left-col">
-                <FastField
-                  component={FormInput}
-                  name="wordCount"
-                  label="Word Count"
-                  type="number"
-                  min="0"
-                  step="50"
-                  editable={editMode}
-                />
+                {!editMode ? (
+                  <>
+                    <b>Word Count</b>
+                    <p>{values.wordCount ? values.wordCount : 'NA'}</p>
+                  </>
+                ) : (
+                  <FastField
+                    component={FormInput}
+                    name="wordCount"
+                    label="Word Count"
+                    type="number"
+                    min="0"
+                    step="50"
+                    editable={editMode}
+                  />
+                )}
               </div>
               <div className="right-col">
-                <FastField
-                  component={FormInput}
-                  name="pageCount"
-                  label="Page Count"
-                  type="number"
-                  min="0"
-                  step="0.5"
-                  editable={editMode}
-                />
+                {!editMode ? (
+                  <>
+                    <b>Page Count</b>
+                    <p>{values.pageCount ? values.pageCount : 'NA'}</p>
+                  </>
+                ) : (
+                  <FastField
+                    component={FormInput}
+                    name="pageCount"
+                    label="Page Count"
+                    type="number"
+                    min="0"
+                    step="0.5"
+                    editable={editMode}
+                  />
+                )}
               </div>
             </div>
 

--- a/client/src/components/form/ReviewClaimForm.tsx
+++ b/client/src/components/form/ReviewClaimForm.tsx
@@ -38,6 +38,8 @@ interface FormData
     | 'topics'
     | 'assignmentGoogleDocLink'
     | 'description'
+    | 'wordCount'
+    | 'pageCount'
   > {
   issueStatuses: FullPopulatedPitch['issueStatuses'];
   deadline: string;
@@ -49,6 +51,8 @@ const fields: (keyof FormData)[] = [
   'topics',
   'assignmentGoogleDocLink',
   'description',
+  'wordCount',
+  'pageCount',
   'deadline',
   'issueStatuses',
 ];
@@ -247,6 +251,30 @@ export const ReviewClaimForm: FC<FormProps> = ({
                 />
               </div>
             </Form>
+
+            <div className="row">
+              <div className="left-col">
+                <FastField
+                  component={FormInput}
+                  name="wordCount"
+                  label="Word Count"
+                  type="number"
+                  min="0"
+                  step="50"
+                  editable={editMode}
+                />
+              </div>
+              <div className="right-col">
+                <FastField
+                  component={FormInput}
+                  name="pageCount"
+                  label="Page Count"
+                  type="number"
+                  min="0"
+                  editable={editMode}
+                />
+              </div>
+            </div>
 
             <div className={editMode ? 'column' : 'row'}>
               <div className={editMode ? 'issue-column' : 'left-col'}>

--- a/client/src/components/form/ReviewClaimForm.tsx
+++ b/client/src/components/form/ReviewClaimForm.tsx
@@ -271,6 +271,7 @@ export const ReviewClaimForm: FC<FormProps> = ({
                   label="Page Count"
                   type="number"
                   min="0"
+                  step="0.5"
                   editable={editMode}
                 />
               </div>

--- a/client/src/components/kanban/KanbanCard.tsx
+++ b/client/src/components/kanban/KanbanCard.tsx
@@ -34,6 +34,9 @@ const KanbanCard: FC<PitchProps> = ({ pitch, ...rest }): ReactElement => {
             : new Date().toLocaleDateString()}
         </p>
       </div>
+      <p className="pitch-text">
+        Page Count: {pitch.pageCount ? pitch.pageCount : 'N/A'}
+      </p>
     </Card>
   );
 };

--- a/client/src/components/kanban/KanbanCard.tsx
+++ b/client/src/components/kanban/KanbanCard.tsx
@@ -35,7 +35,7 @@ const KanbanCard: FC<PitchProps> = ({ pitch, ...rest }): ReactElement => {
         </p>
       </div>
       <p className="pitch-text">
-        Page Count: {pitch.pageCount ? pitch.pageCount : 'N/A'}
+        Page Count: {pitch.pageCount ? pitch.pageCount : 'NA'}
       </p>
     </Card>
   );

--- a/client/src/components/modal/ReviewPitch.scss
+++ b/client/src/components/modal/ReviewPitch.scss
@@ -15,6 +15,13 @@
       color: $secondaryColor !important;
     }
 
+    #page-word-count {
+      display: flex;
+      #word-count {
+        margin-right: 20px;
+      }
+    }
+
     #date-issue-selector {
       display: flex;
       margin-top: 20px;

--- a/client/src/components/modal/ReviewPitch.tsx
+++ b/client/src/components/modal/ReviewPitch.tsx
@@ -62,6 +62,8 @@ export const ReviewPitch: FC<ReviewPitchProps> = ({
   );
   const [pitchIssues, setPitchIssues] = useState<string[]>([]);
   const [reasoning, setReasoning] = useState('');
+  const [wordCount, setWordCount] = useState(0);
+  const [pageCount, setPageCount] = useState(0);
 
   useEffect(() => {
     const loadData = async (): Promise<void> => {
@@ -118,6 +120,8 @@ export const ReviewPitch: FC<ReviewPitchProps> = ({
       neighborhoods: pitchNeighborhoods,
       teams: parsedTeams,
       deadline: new Date(deadline),
+      wordCount: wordCount,
+      pageCount: pageCount,
       issueStatuses: pitchIssues
         .map((issueId) => ({
           issueId,
@@ -372,6 +376,31 @@ export const ReviewPitch: FC<ReviewPitchProps> = ({
                   </div>
                 </div>
               ))}
+          </div>
+        </div>
+        <div className="section">
+          <div>
+            <p>
+              <b>Word Count</b>
+            </p>
+            <Input
+              type="number"
+              value={wordCount}
+              step="50"
+              min={0}
+              onChange={(e, { value }) => setWordCount(parseInt(value))}
+            />
+          </div>
+          <div>
+            <p>
+              <b>Page Count</b>
+            </p>
+            <Input
+              type="number"
+              value={pageCount}
+              min={0}
+              onChange={(e, { value }) => setPageCount(parseInt(value))}
+            />
           </div>
         </div>
         <div className="section" id="date-issue-selector">

--- a/client/src/components/modal/ReviewPitch.tsx
+++ b/client/src/components/modal/ReviewPitch.tsx
@@ -378,8 +378,8 @@ export const ReviewPitch: FC<ReviewPitchProps> = ({
               ))}
           </div>
         </div>
-        <div className="section">
-          <div>
+        <div className="section" id="page-word-count">
+          <div id="word-count">
             <p>
               <b>Word Count</b>
             </p>
@@ -388,6 +388,7 @@ export const ReviewPitch: FC<ReviewPitchProps> = ({
               value={wordCount}
               step="50"
               min={0}
+              style={{ width: '100px' }}
               onChange={(e, { value }) => setWordCount(parseInt(value))}
             />
           </div>
@@ -399,7 +400,9 @@ export const ReviewPitch: FC<ReviewPitchProps> = ({
               type="number"
               value={pageCount}
               min={0}
-              onChange={(e, { value }) => setPageCount(parseInt(value))}
+              step="0.5"
+              style={{ width: '100px' }}
+              onChange={(e, { value }) => setPageCount(parseFloat(value))}
             />
           </div>
         </div>


### PR DESCRIPTION
## Summary
On each Pitch, a page and word count will be added so contributors are aware of the length of their document.

## Changes
- Added `wordCount` and `pageCount` field to Pitch model 
- Added input fields for word count and page count on ReviewPitch form
- Added input fields for word count and page count on ReviewClaim form
- Display page count on kanban card