### PR TITLE
Profile Current Pitch Filter

### DIFF
--- a/client/src/components/table/dynamic/PaginatedTable.tsx
+++ b/client/src/components/table/dynamic/PaginatedTable.tsx
@@ -45,7 +45,7 @@ export const PaginatedTable = <T,>({
   return (
     <div>
       <div style={{ display: 'flex', marginTop: '20px', alignItems: 'center' }}>
-        <span>Records per page: </span>
+        <span style={{ marginRight: '2px' }}>Records per page: </span>
         <SingleSelect
           value={query.limit || '10'}
           options={parseOptionsSelect(pageOptions)}
@@ -53,7 +53,7 @@ export const PaginatedTable = <T,>({
           placeholder="Limit"
         />
         <br />
-        <div>
+        <div style={{ marginLeft: '1em' }}>
           <p>Total count: {count}</p>
         </div>
       </div>

--- a/client/src/pages/Profile.scss
+++ b/client/src/pages/Profile.scss
@@ -3,11 +3,17 @@
     padding-left: 5% !important;
   }
 
-  .published-filter {
+  .table-filters {
     display: flex;
     flex-direction: row;
+    align-items: center;
+    vertical-align: middle;
     .published-checkbox {
       margin-right: 10px;
+    }
+    .search {
+      width: 30em;
+      margin-right: 2em;
     }
   }
 

--- a/client/src/pages/Profile.scss
+++ b/client/src/pages/Profile.scss
@@ -3,6 +3,14 @@
     padding-left: 5% !important;
   }
 
+  .published-filter {
+    display: flex;
+    flex-direction: row;
+    .published-checkbox {
+      margin-right: 10px;
+    }
+  }
+
   .tag-spacing {
     margin-top: 2% !important;
   }

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -13,7 +13,13 @@ import {
   Team,
   User,
 } from 'ssw-common';
-import { Grid, Pagination, Rating, SemanticWIDTHS } from 'semantic-ui-react';
+import {
+  Checkbox,
+  Grid,
+  Pagination,
+  Rating,
+  SemanticWIDTHS,
+} from 'semantic-ui-react';
 import _ from 'lodash';
 import { BooleanParam, StringParam, useQueryParams } from 'use-query-params';
 
@@ -35,7 +41,6 @@ import { pitchStatusEnum } from '../utils/enums';
 import { RadioFilter } from '../components/filter/RadioFilter';
 
 import './Profile.scss';
-
 interface PitchesRes {
   data: BasePopulatedPitch[];
   count: number;
@@ -55,11 +60,12 @@ const Profile = (): ReactElement => {
     offset: StringParam,
     f_limit: StringParam,
     f_offset: StringParam,
-    isPublished: BooleanParam
+    isPublished: BooleanParam,
   });
   const [user, setUser] = useState<BasePopulatedUser>();
   const [pitchesData, setPitchesData] = useState<PitchesRes>();
   const [feedbackData, setFeedbackData] = useState<FeedbackRes>();
+  const [currentPitches, setCurrentPitches] = useState(false);
 
   const location = useLocation();
   const history = useHistory();
@@ -146,12 +152,19 @@ const Profile = (): ReactElement => {
 
   useEffect(() => {
     const loadPitches = async (): Promise<void> => {
-      const res = await apiCall<PitchesRes>({
-        url: `/users/${user?._id}/pitches`,
-        method: 'GET',
-        populate: 'default',
-        query: queryParams,
-      });
+      const res = currentPitches
+        ? await apiCall<PitchesRes>({
+            url: `/users/${user?._id}/currentPitches`,
+            method: 'GET',
+            populate: 'default',
+            query: queryParams,
+          })
+        : await apiCall<PitchesRes>({
+            url: `/users/${user?._id}/pitches`,
+            method: 'GET',
+            populate: 'default',
+            query: queryParams,
+          });
 
       if (!isError(res)) {
         setPitchesData(res.data.result);
@@ -162,7 +175,7 @@ const Profile = (): ReactElement => {
       return;
     }
     loadPitches();
-  }, [queryParams, user]);
+  }, [queryParams, user, currentPitches]);
 
   useEffect(() => {
     const loadFeedback = async (): Promise<void> => {
@@ -394,17 +407,24 @@ const Profile = (): ReactElement => {
         ) : (
           <h2>{`${user.firstName}'s` + ` Contributions`}</h2>
         )}
-        <RadioFilter
-          className="published-checkbox"
-          label="Published"
-          filterKey="isPublished"
-        />
-        <RadioFilter
-          className="published-checkbox"
-          label="Not Published"
-          value="false"
-          filterKey="isPublished"
-        />
+
+        <div className="published-filter">
+          <RadioFilter
+            className="published-checkbox"
+            label="Published"
+            filterKey="isPublished"
+          />
+          <RadioFilter
+            className="published-checkbox"
+            label="Not Published"
+            value="false"
+            filterKey="isPublished"
+          />
+          <Checkbox
+            label="Current Pitches"
+            onChange={() => setCurrentPitches(!currentPitches)}
+          ></Checkbox>
+        </div>
 
         <PaginatedTable
           columns={cols}

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -15,7 +15,7 @@ import {
 } from 'ssw-common';
 import { Grid, Pagination, Rating, SemanticWIDTHS } from 'semantic-ui-react';
 import _ from 'lodash';
-import { StringParam, useQueryParams } from 'use-query-params';
+import { BooleanParam, StringParam, useQueryParams } from 'use-query-params';
 
 import { loadFullUser, loadUserPermissions } from '../api/apiWrapper';
 import { FieldTag, UserPicture } from '../components';
@@ -32,6 +32,7 @@ import { parseOptionsSelect } from '../utils/helpers';
 import Loading from '../components/ui/Loading';
 import { pitchStatusCol } from '../components/table/columns';
 import { pitchStatusEnum } from '../utils/enums';
+import { RadioFilter } from '../components/filter/RadioFilter';
 
 import './Profile.scss';
 
@@ -54,6 +55,7 @@ const Profile = (): ReactElement => {
     offset: StringParam,
     f_limit: StringParam,
     f_offset: StringParam,
+    isPublished: BooleanParam
   });
   const [user, setUser] = useState<BasePopulatedUser>();
   const [pitchesData, setPitchesData] = useState<PitchesRes>();
@@ -119,6 +121,7 @@ const Profile = (): ReactElement => {
     const q = {
       limit: params.get('f_limit') || '10',
       offset: params.get('f_offset') || '0',
+      isPublished: params.get('isPublished'),
     };
 
     return _.omitBy(q, _.isNil);
@@ -392,6 +395,17 @@ const Profile = (): ReactElement => {
         ) : (
           <h2>{`${user.firstName}'s` + ` Contributions`}</h2>
         )}
+        <RadioFilter
+          className="published-checkbox"
+          label="Published"
+          filterKey="isPublished"
+        />
+        <RadioFilter
+          className="published-checkbox"
+          label="Not Published"
+          value="false"
+          filterKey="isPublished"
+        />
 
         <PaginatedTable
           columns={cols}

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -39,6 +39,7 @@ import Loading from '../components/ui/Loading';
 import { pitchStatusCol } from '../components/table/columns';
 import { pitchStatusEnum } from '../utils/enums';
 import { RadioFilter } from '../components/filter/RadioFilter';
+import { DelayedSearch } from '../components/search/DelayedSearch';
 
 import './Profile.scss';
 interface PitchesRes {
@@ -115,6 +116,7 @@ const Profile = (): ReactElement => {
       sortBy: params.get('sortBy'),
       orderBy: params.get('orderBy'),
       isPublished: params.get('isPublished'),
+      search: params.get('search'),
     };
 
     return _.omitBy(q, _.isNil);
@@ -408,7 +410,8 @@ const Profile = (): ReactElement => {
           <h2>{`${user.firstName}'s` + ` Contributions`}</h2>
         )}
 
-        <div className="published-filter">
+        <div className="table-filters">
+          <DelayedSearch className="search"></DelayedSearch>
           <RadioFilter
             className="published-checkbox"
             label="Published"
@@ -421,7 +424,7 @@ const Profile = (): ReactElement => {
             filterKey="isPublished"
           />
           <Checkbox
-            label="Current Pitches"
+            label="Show Current Pitches Only"
             onChange={() => setCurrentPitches(!currentPitches)}
           ></Checkbox>
         </div>

--- a/client/src/pages/Profile.tsx
+++ b/client/src/pages/Profile.tsx
@@ -108,6 +108,7 @@ const Profile = (): ReactElement => {
       offset: params.get('offset') || '0',
       sortBy: params.get('sortBy'),
       orderBy: params.get('orderBy'),
+      isPublished: params.get('isPublished'),
     };
 
     return _.omitBy(q, _.isNil);
@@ -121,7 +122,6 @@ const Profile = (): ReactElement => {
     const q = {
       limit: params.get('f_limit') || '10',
       offset: params.get('f_offset') || '0',
-      isPublished: params.get('isPublished'),
     };
 
     return _.omitBy(q, _.isNil);
@@ -161,7 +161,6 @@ const Profile = (): ReactElement => {
     if (!user) {
       return;
     }
-
     loadPitches();
   }, [queryParams, user]);
 

--- a/client/src/utils/helpers.ts
+++ b/client/src/utils/helpers.ts
@@ -58,7 +58,7 @@ const getPitchTeamsForContributor = (
 
   const contributor = pitch.assignmentContributors.find(isUser)?.teams || [];
 
-  if (user._id === pitch.writer._id) {
+  if (pitch.writer && user._id === pitch.writer._id) {
     contributor.push(WRITING_TEAM);
   }
 


### PR DESCRIPTION
## Summary 

The Current Pitch filter currently exists on the Home Page, where contributors can see the current pitches that they are currently working on. Create a filter on the Profile Page that calls the `/users/:id/currentPitches` endpoint the profile page user’s id and updates the pitches in the table. 

## Changes
- Added Current Pitch filter on profile page
- Added Published filter on profile page 
- Added Search Bar on profile page
- Adjusted table stylings
