### PR TITLE
Moving Back to Pages with Preserved State

### DIFF
--- a/client/src/pages/Issues.tsx
+++ b/client/src/pages/Issues.tsx
@@ -1,6 +1,7 @@
 import React, { ReactElement, useCallback, useEffect, useState } from 'react';
 import { Icon } from 'semantic-ui-react';
 import { PopulatedIssue } from 'ssw-common';
+import { useQueryParams, NumberParam } from 'use-query-params';
 
 import { isError, apiCall } from '../api';
 import { Kanban } from '../components';
@@ -17,6 +18,7 @@ const Issues = (): ReactElement => {
   const [issues, setIssues] = useState<PopulatedIssue[] | null>(null);
   const [viewIssueIndex, setViewIssueIndex] = useState<number>(0);
   const { isAdmin } = useAuth();
+  const [query, setQuery] = useQueryParams({ index: NumberParam });
 
   const fetchIssues = useCallback(async (): Promise<void> => {
     const res = await apiCall<{ data: PopulatedIssue[]; count: number }>({
@@ -37,10 +39,14 @@ const Issues = (): ReactElement => {
         (issue) => new Date() >= new Date(issue.releaseDate),
       );
 
-      if (closestIssueIndex < 0) {
-        setViewIssueIndex(allIssues.length - 1);
+      if (query.index === undefined) {
+        if (closestIssueIndex < 0) {
+          setViewIssueIndex(allIssues.length - 1);
+        } else {
+          setViewIssueIndex(closestIssueIndex);
+        }
       } else {
-        setViewIssueIndex(closestIssueIndex);
+        setViewIssueIndex(query.index || 0);
       }
 
       setIssues(allIssues);
@@ -48,6 +54,10 @@ const Issues = (): ReactElement => {
       setIssues([]);
     }
   }, []);
+
+  useEffect(() => {
+    setQuery({ index: viewIssueIndex });
+  }, [setQuery, viewIssueIndex]);
 
   useEffect(() => {
     fetchIssues();

--- a/client/src/pages/Issues.tsx
+++ b/client/src/pages/Issues.tsx
@@ -17,8 +17,8 @@ import './Issues.scss';
 const Issues = (): ReactElement => {
   const [issues, setIssues] = useState<PopulatedIssue[] | null>(null);
   const [viewIssueIndex, setViewIssueIndex] = useState<number>(0);
-  const { isAdmin } = useAuth();
   const [query, setQuery] = useQueryParams({ index: NumberParam });
+  const { isAdmin } = useAuth();
 
   const fetchIssues = useCallback(async (): Promise<void> => {
     const res = await apiCall<{ data: PopulatedIssue[]; count: number }>({
@@ -35,16 +35,13 @@ const Issues = (): ReactElement => {
           new Date(b.releaseDate).getTime() - new Date(a.releaseDate).getTime(),
       );
 
-      const closestIssueIndex = allIssues.findIndex(
-        (issue) => new Date() >= new Date(issue.releaseDate),
-      );
-
       if (query.index === undefined) {
-        if (closestIssueIndex < 0) {
-          setViewIssueIndex(allIssues.length - 1);
-        } else {
-          setViewIssueIndex(closestIssueIndex);
-        }
+        const closestIssueIndex = allIssues.findIndex(
+          (issue) => new Date() >= new Date(issue.releaseDate),
+        );
+        setViewIssueIndex(
+          closestIssueIndex < 0 ? allIssues.length - 1 : closestIssueIndex,
+        );
       } else {
         setViewIssueIndex(query.index || 0);
       }
@@ -53,7 +50,7 @@ const Issues = (): ReactElement => {
     } else {
       setIssues([]);
     }
-  }, []);
+  }, [query.index]);
 
   useEffect(() => {
     fetchIssues();

--- a/client/src/pages/Issues.tsx
+++ b/client/src/pages/Issues.tsx
@@ -56,10 +56,6 @@ const Issues = (): ReactElement => {
   }, []);
 
   useEffect(() => {
-    setQuery({ index: viewIssueIndex });
-  }, [setQuery, viewIssueIndex]);
-
-  useEffect(() => {
     fetchIssues();
   }, [fetchIssues]);
 
@@ -99,11 +95,13 @@ const Issues = (): ReactElement => {
               value: issue._id,
             }))}
             value={issues[viewIssueIndex] ? issues[viewIssueIndex]._id : ''}
-            onChange={(e) =>
-              setViewIssueIndex(
-                issues.findIndex((issue) => issue._id === e?.value),
-              )
-            }
+            onChange={(e) => {
+              const newIndex = issues.findIndex(
+                (issue) => issue._id === e?.value,
+              );
+              setViewIssueIndex(newIndex);
+              setQuery({ index: newIndex });
+            }}
             isClearable={false}
           />
 


### PR DESCRIPTION
## Summary
When clicking in to view certain pitches, it is hard to return to the previous pages because it doesn’t go back to a specific issue within the page. It just returns to the default first issue.
