### PR TITLE
New Status and Link for FC/Layout/Visuals

### DIFF
--- a/api/src/models/pitch.model.ts
+++ b/api/src/models/pitch.model.ts
@@ -101,13 +101,13 @@ const Pitch = new mongoose.Schema(
       enum: Object.values(factCheckingStatusEnum),
       default: factCheckingStatusEnum.NEEDS_FC,
     },
-    factCheckingLink: { type: String, default: null },
+    factCheckingLink: { type: String, default: '' },
     visualStatus: {
       type: String,
       enum: Object.values(visualStatusEnum),
       default: visualStatusEnum.UNASSIGNED,
     },
-    visualLink: { type: String, default: null },
+    visualLink: { type: String, default: '' },
     visualNotes: { type: String, default: null },
     layoutStatus: {
       type: String,

--- a/api/src/models/pitch.model.ts
+++ b/api/src/models/pitch.model.ts
@@ -6,6 +6,9 @@ import {
   assignmentStatusEnum,
   issueStatusEnum,
   editStatusEnum,
+  factCheckingStatusEnum,
+  visualStatusEnum,
+  layoutStatusEnum,
 } from '../utils/enums';
 
 export type PitchSchema = Pitch & Document<any>;
@@ -92,6 +95,23 @@ const Pitch = new mongoose.Schema(
       type: String,
       enum: Object.values(editStatusEnum),
       default: editStatusEnum.WRITER_NEEDED,
+    },
+    factCheckingStatus: {
+      type: String,
+      enum: Object.values(factCheckingStatusEnum),
+      default: factCheckingStatusEnum.NEEDS_FC,
+    },
+    factCheckingLink: { type: String, default: null },
+    visualStatus: {
+      type: String,
+      enum: Object.values(visualStatusEnum),
+      default: visualStatusEnum.UNASSIGNED,
+    },
+    visualLink: { type: String, default: null },
+    layoutStatus: {
+      type: String,
+      enum: Object.values(layoutStatusEnum),
+      default: layoutStatusEnum.IN_PROGRESS,
     },
     wordCount: { type: Number, default: null },
     pageCount: { type: Number, default: null },

--- a/api/src/models/pitch.model.ts
+++ b/api/src/models/pitch.model.ts
@@ -108,11 +108,13 @@ const Pitch = new mongoose.Schema(
       default: visualStatusEnum.UNASSIGNED,
     },
     visualLink: { type: String, default: null },
+    visualNotes: { type: String, default: null },
     layoutStatus: {
       type: String,
       enum: Object.values(layoutStatusEnum),
       default: layoutStatusEnum.IN_PROGRESS,
     },
+    layoutNotes: { type: String, default: null },
     wordCount: { type: Number, default: null },
     pageCount: { type: Number, default: null },
   },

--- a/api/src/utils/enums.ts
+++ b/api/src/utils/enums.ts
@@ -89,6 +89,30 @@ const editStatusEnum = {
   TRANSLATION_IP: 'Translation In Progress',
 };
 
+const factCheckingStatusEnum = {
+  NEEDS_FC: 'Needs FC',
+  FC_IN_PROGRESS: 'FC In Progress',
+  FC_DONE: 'FC Done',
+  NOT_INTEGRATED: 'Not Integrated',
+  FC_INTEGRATED: 'FC Integrated',
+};
+
+const visualStatusEnum = {
+  UNASSIGNED: 'Unassigned',
+  IN_PROGRESS: 'In Progress',
+  REUSE_ILLUSTRATION: 'Re-use Illustration',
+  IN_DRIVE: 'In Drive',
+  UNCERTAIN: 'Uncertain',
+};
+
+const layoutStatusEnum = {
+  IN_PROGRESS: 'In Progress',
+  LAYOUT_DRAFTED: 'Layout Drafted',
+  COPY_PLACED: 'Copy Placed',
+  BOARD_PRINTED: 'Board Printed',
+  FINALIZED: 'Finalized',
+};
+
 export {
   issueTypeEnum,
   rolesEnum,
@@ -102,4 +126,7 @@ export {
   editStatusEnum,
   claimStatusEnum,
   editorTypeEnum,
+  factCheckingStatusEnum,
+  visualStatusEnum,
+  layoutStatusEnum,
 };

--- a/api/src/utils/enums.ts
+++ b/api/src/utils/enums.ts
@@ -101,8 +101,8 @@ const visualStatusEnum = {
   UNASSIGNED: 'Unassigned',
   IN_PROGRESS: 'In Progress',
   REUSE_ILLUSTRATION: 'Re-use Illustration',
-  IN_DRIVE: 'In Drive',
   UNCERTAIN: 'Uncertain',
+  IN_DRIVE: 'In Drive',
 };
 
 const layoutStatusEnum = {

--- a/client/src/components/form/ReviewClaimForm.tsx
+++ b/client/src/components/form/ReviewClaimForm.tsx
@@ -45,7 +45,9 @@ interface FormData
     | 'factCheckingLink'
     | 'visualStatus'
     | 'visualLink'
+    | 'visualNotes'
     | 'layoutStatus'
+    | 'layoutNotes'
     | 'topics'
     | 'assignmentGoogleDocLink'
     | 'description'
@@ -63,7 +65,9 @@ const fields: (keyof FormData)[] = [
   'factCheckingLink',
   'visualStatus',
   'visualLink',
+  'visualNotes',
   'layoutStatus',
+  'layoutNotes',
   'topics',
   'assignmentGoogleDocLink',
   'description',
@@ -296,14 +300,26 @@ export const ReviewClaimForm: FC<FormProps> = ({
                 )}
               </div>
             </div>
-            <div className="row">
-              <FastField
-                component={FormInput}
-                name="visualNotes"
-                label="Visuals Notes"
-                editable={editMode}
-              />
-            </div>
+            {pitch.visualNotes && !editMode && (
+              <div className="row">
+                <FastField
+                  component={FormInput}
+                  name="visualNotes"
+                  label="Visuals Notes"
+                  editable={editMode}
+                />
+              </div>
+            )}
+            {editMode && (
+              <div className="row">
+                <FastField
+                  component={FormInput}
+                  name="visualNotes"
+                  label="Visuals Notes"
+                  editable={editMode}
+                />
+              </div>
+            )}
             <div className="row">
               <div className="left-col">
                 <FastField
@@ -318,14 +334,26 @@ export const ReviewClaimForm: FC<FormProps> = ({
                 />
               </div>
             </div>
-            <div className="row">
-              <FastField
-                component={FormInput}
-                name="layoutNotes"
-                label="Layout Notes"
-                editable={editMode}
-              />
-            </div>
+            {pitch.layoutNotes && !editMode && (
+              <div className="row">
+                <FastField
+                  component={FormInput}
+                  name="layoutNotes"
+                  label="Layout Notes"
+                  editable={editMode}
+                />
+              </div>
+            )}
+            {editMode && (
+              <div className="row">
+                <FastField
+                  component={FormInput}
+                  name="layoutNotes"
+                  label="Layout Notes"
+                  editable={editMode}
+                />
+              </div>
+            )}
             <div className="row">
               <FastField
                 component={FormMultiSelect}
@@ -471,6 +499,7 @@ export const ReviewClaimForm: FC<FormProps> = ({
                           {formatIssue(issueId.releaseDate, issueId.type)}
                         </p>
                         <FieldTag
+                          size="medium"
                           content={startCase(lowerCase(issueStatus))}
                           className="issue-tag"
                         />

--- a/client/src/components/form/ReviewClaimForm.tsx
+++ b/client/src/components/form/ReviewClaimForm.tsx
@@ -297,6 +297,14 @@ export const ReviewClaimForm: FC<FormProps> = ({
               </div>
             </div>
             <div className="row">
+              <FastField
+                component={FormInput}
+                name="visualNotes"
+                label="Visuals Notes"
+                editable={editMode}
+              />
+            </div>
+            <div className="row">
               <div className="left-col">
                 <FastField
                   component={FormSingleSelect}
@@ -309,6 +317,14 @@ export const ReviewClaimForm: FC<FormProps> = ({
                   editable={editMode}
                 />
               </div>
+            </div>
+            <div className="row">
+              <FastField
+                component={FormInput}
+                name="layoutNotes"
+                label="Layout Notes"
+                editable={editMode}
+              />
             </div>
             <div className="row">
               <FastField

--- a/client/src/components/form/ReviewClaimForm.tsx
+++ b/client/src/components/form/ReviewClaimForm.tsx
@@ -9,7 +9,13 @@ import { FieldTag } from '..';
 import { apiCall, isError } from '../../api';
 import { useInterests } from '../../contexts';
 import { useIssues } from '../../contexts/issues/context';
-import { editStatusEnum, issueStatusEnum } from '../../utils/enums';
+import {
+  editStatusEnum,
+  issueStatusEnum,
+  factCheckingStatusEnum,
+  visualStatusEnum,
+  layoutStatusEnum,
+} from '../../utils/enums';
 import { formatDate } from '../../utils/helpers';
 import AddIssue from '../modal/AddIssue';
 import { MultiSelect } from '../select/MultiSelect';
@@ -35,6 +41,11 @@ interface FormData
     Pitch,
     | 'title'
     | 'editStatus'
+    | 'factCheckingStatus'
+    | 'factCheckingLink'
+    | 'visualStatus'
+    | 'visualLink'
+    | 'layoutStatus'
     | 'topics'
     | 'assignmentGoogleDocLink'
     | 'description'
@@ -48,6 +59,11 @@ interface FormData
 const fields: (keyof FormData)[] = [
   'title',
   'editStatus',
+  'factCheckingStatus',
+  'factCheckingLink',
+  'visualStatus',
+  'visualLink',
+  'layoutStatus',
   'topics',
   'assignmentGoogleDocLink',
   'description',
@@ -223,6 +239,78 @@ export const ReviewClaimForm: FC<FormProps> = ({
               </div>
             </div>
             <div className="row">
+              <div className="left-col">
+                <FastField
+                  component={FormSingleSelect}
+                  options={Object.values(factCheckingStatusEnum).map(
+                    (status) => ({
+                      value: status,
+                      label: status,
+                    }),
+                  )}
+                  name="factCheckingStatus"
+                  label="Fact Checking Status"
+                  editable={editMode}
+                />
+              </div>
+              <div className="right-col">
+                {!editMode ? (
+                  <p>
+                    <b>Fact Checking Link</b>
+                    <LinkDisplay href={values.factCheckingLink} />
+                  </p>
+                ) : (
+                  <FastField
+                    component={FormInput}
+                    name="factCheckingLink"
+                    label="Fact Checking Link"
+                  />
+                )}
+              </div>
+            </div>
+            <div className="row">
+              <div className="left-col">
+                <FastField
+                  component={FormSingleSelect}
+                  options={Object.values(visualStatusEnum).map((status) => ({
+                    value: status,
+                    label: status,
+                  }))}
+                  name="visualStatus"
+                  label="Visuals Status"
+                  editable={editMode}
+                />
+              </div>
+              <div className="right-col">
+                {!editMode ? (
+                  <p>
+                    <b>Visuals Link</b>
+                    <LinkDisplay href={values.visualLink} />
+                  </p>
+                ) : (
+                  <FastField
+                    component={FormInput}
+                    name="visualLink"
+                    label="Visuals Link"
+                  />
+                )}
+              </div>
+            </div>
+            <div className="row">
+              <div className="left-col">
+                <FastField
+                  component={FormSingleSelect}
+                  options={Object.values(layoutStatusEnum).map((status) => ({
+                    value: status,
+                    label: status,
+                  }))}
+                  name="layoutStatus"
+                  label="Layout Status"
+                  editable={editMode}
+                />
+              </div>
+            </div>
+            <div className="row">
               <FastField
                 component={FormMultiSelect}
                 name="topics"
@@ -237,7 +325,10 @@ export const ReviewClaimForm: FC<FormProps> = ({
             </div>
             <div className="row">
               {!editMode ? (
-                <LinkDisplay href={values.assignmentGoogleDocLink} />
+                <p>
+                  <b>Google Doc Link</b>
+                  <LinkDisplay href={values.assignmentGoogleDocLink} />
+                </p>
               ) : (
                 <FastField
                   component={FormInput}

--- a/client/src/components/kanban/Kanban.scss
+++ b/client/src/components/kanban/Kanban.scss
@@ -29,8 +29,8 @@
 
   .kanban-column {
     padding: 4px;
-    width: 225px;
-    height: 500px;
+    width: 250px;
+    height: 70vh;
     overflow-y: auto;
 
     &.dragging {

--- a/client/src/components/kanban/KanbanCard.scss
+++ b/client/src/components/kanban/KanbanCard.scss
@@ -7,11 +7,14 @@
   min-height: 65px;
   background-color: $mainBackground !important;
   height: fit-content !important;
-  margin: 10px 0px 10px 0px !important;
+  margin: 5px 0px 10px 0px !important;
   padding: 10px 2px 10px 10px !important;
 
   * {
     color: black !important;
+    .due-date {
+      color: gray !important;
+    }
   }
 
   display: flex;
@@ -25,18 +28,14 @@
   font-size: 12px;
   line-height: 25px;
 
-  .pitch-title {
-    font-weight: 600;
-  }
-
   .pitch-info {
     display: flex;
-    flex-direction: row;
-    align-items: center;
+    flex-direction: column;
     justify-content: left !important;
     width: 100%;
     position: relative;
     right: 5px;
+    left: 2px;
     top: -4px;
 
     .pitch-text {

--- a/client/src/components/kanban/KanbanCard.scss
+++ b/client/src/components/kanban/KanbanCard.scss
@@ -10,6 +10,25 @@
   margin: 5px 0px 10px 0px !important;
   padding: 10px 2px 10px 10px !important;
 
+  .page-word-count {
+    position: relative;
+    left: 2px;
+    display: flex;
+    flex-direction: row;
+    width: 100%;
+
+    #left {
+      width: 50% !important;
+      position: relative !important;
+      float: left !important;
+    }
+    #right {
+      width: 50% !important;
+      position: relative !important;
+      float: right !important;
+    }
+  }
+
   * {
     color: black !important;
     .due-date {

--- a/client/src/components/kanban/KanbanCard.tsx
+++ b/client/src/components/kanban/KanbanCard.tsx
@@ -68,8 +68,13 @@ const KanbanCard: FC<PitchProps> = ({ pitch, ...rest }): ReactElement => {
           />
         </dt>
       </div>
-      <p className="pitch-text">
-        Page Count: {pitch.pageCount ? pitch.pageCount : 'NA'}
+      <p className="page-word-count">
+        <span id="left">
+          Word Count: {pitch.wordCount ? pitch.wordCount : 'NA'}
+        </span>
+        <span id="right">
+          Page Count: {pitch.pageCount ? pitch.pageCount : 'NA'}
+        </span>
       </p>
     </Card>
   );

--- a/client/src/components/kanban/KanbanCard.tsx
+++ b/client/src/components/kanban/KanbanCard.tsx
@@ -20,19 +20,53 @@ const KanbanCard: FC<PitchProps> = ({ pitch, ...rest }): ReactElement => {
       onClick={() => history.push(`pitch/${pitch._id}`)}
       className={cn('kanban-pitch', rest.className)}
     >
-      <p className="pitch-title">{pitch.title}</p>
-      <div className="pitch-info">
-        <FieldTag
-          size="small"
-          name={pitch.editStatus}
-          content={pitch.editStatus}
-        />
-        <p className="pitch-text">
+      <p className="pitch-text">
+        <b>{pitch.title} </b>
+        <span className="due-date">
+          {' '}
           Due{' '}
           {pitch.deadline
             ? new Date(pitch.deadline).toLocaleDateString()
             : new Date().toLocaleDateString()}
-        </p>
+        </span>
+      </p>
+      <div className="pitch-info">
+        <dt>
+          Edit
+          <> </>
+          <FieldTag
+            size="mini"
+            name={pitch.editStatus}
+            content={pitch.editStatus}
+          />
+        </dt>
+        <dt>
+          Fact Checking
+          <> </>
+          <FieldTag
+            size="mini"
+            name={pitch.factCheckingStatus}
+            content={pitch.factCheckingStatus}
+          />
+        </dt>
+        <dt>
+          Visuals
+          <> </>
+          <FieldTag
+            size="mini"
+            name={pitch.visualStatus}
+            content={pitch.visualStatus}
+          />
+        </dt>
+        <dt>
+          Layout
+          <> </>
+          <FieldTag
+            size="mini"
+            name={pitch.layoutStatus}
+            content={pitch.layoutStatus}
+          />
+        </dt>
       </div>
       <p className="pitch-text">
         Page Count: {pitch.pageCount ? pitch.pageCount : 'NA'}

--- a/client/src/components/tag/FieldTag.scss
+++ b/client/src/components/tag/FieldTag.scss
@@ -178,8 +178,6 @@
   background-color: $tagOrange !important;
 }
 
-// Fact Checking Status Colors
-
 .needs-fc-tag-color,
 .fc-in-progress-tag-color,
 .not-integrated-tag-color,
@@ -191,8 +189,6 @@
   background-color: $tagGreen !important;
 }
 
-// Visuals Status Colors
-
 .unassigned-tag-color,
 .re-use-illustration-tag-color,
 .uncertain-tag-color {
@@ -202,8 +198,6 @@
 .in-drive-tag-color {
   background-color: $tagGreen !important;
 }
-
-// Layout Status Colors
 
 .layout-drafted-tag-color,
 .copy-placed-tag-color,

--- a/client/src/components/tag/FieldTag.scss
+++ b/client/src/components/tag/FieldTag.scss
@@ -177,3 +177,65 @@
 .coming-late-tag-color {
   background-color: $tagOrange !important;
 }
+
+// Fact Checking Status Colors
+
+.needs-fc-tag-color {
+  background-color: $tagRed !important;
+}
+
+.fc-in-progress-tag-color {
+  background-color: $tagYellow !important;
+}
+
+.fc-done-tag-color {
+  background-color: $tagGreen !important;
+}
+
+.not-integrated-tag-color {
+  background-color: $tagOrange !important;
+}
+
+.fc-integrated-tag-color {
+  background-color: $tagBlue !important;
+}
+
+// Visuals Status Colors
+
+.unassigned-tag-color {
+  background-color: $tagRed !important;
+}
+
+.re-use-illustration-tag-color {
+  background-color: $tagBlue !important;
+}
+
+.in-drive-tag-color {
+  background-color: $tagGreen !important;
+}
+
+.uncertain-tag-color {
+  background-color: $tagOrange !important;
+}
+
+// Layout Status Colors
+
+.layout-drafted-tag-color {
+  background-color: $tagYellow !important;
+}
+
+.copy-placed-tag-color {
+  background-color: $tagOrange !important;
+}
+
+.visuals-placed-tag-color {
+  background-color: $tagBlue !important;
+}
+
+.board-printed-tag-color {
+  background-color: $tagPurple !important;
+}
+
+.finalized-tag-color {
+  background-color: $tagGreen !important;
+}

--- a/client/src/components/tag/FieldTag.scss
+++ b/client/src/components/tag/FieldTag.scss
@@ -180,60 +180,36 @@
 
 // Fact Checking Status Colors
 
-.needs-fc-tag-color {
+.needs-fc-tag-color,
+.fc-in-progress-tag-color,
+.not-integrated-tag-color,
+.fc-done-tag-color {
   background-color: $tagRed !important;
 }
 
-.fc-in-progress-tag-color {
-  background-color: $tagYellow !important;
-}
-
-.fc-done-tag-color {
-  background-color: $tagGreen !important;
-}
-
-.not-integrated-tag-color {
-  background-color: $tagOrange !important;
-}
-
 .fc-integrated-tag-color {
-  background-color: $tagBlue !important;
+  background-color: $tagGreen !important;
 }
 
 // Visuals Status Colors
 
-.unassigned-tag-color {
+.unassigned-tag-color,
+.re-use-illustration-tag-color,
+.uncertain-tag-color {
   background-color: $tagRed !important;
-}
-
-.re-use-illustration-tag-color {
-  background-color: $tagBlue !important;
 }
 
 .in-drive-tag-color {
   background-color: $tagGreen !important;
 }
 
-.uncertain-tag-color {
-  background-color: $tagOrange !important;
-}
-
 // Layout Status Colors
 
-.layout-drafted-tag-color {
-  background-color: $tagYellow !important;
-}
-
-.copy-placed-tag-color {
-  background-color: $tagOrange !important;
-}
-
-.visuals-placed-tag-color {
-  background-color: $tagBlue !important;
-}
-
+.layout-drafted-tag-color,
+.copy-placed-tag-color,
+.visuals-placed-tag-color,
 .board-printed-tag-color {
-  background-color: $tagPurple !important;
+  background-color: $tagRed !important;
 }
 
 .finalized-tag-color {

--- a/client/src/components/ui/FormSingleSelect.tsx
+++ b/client/src/components/ui/FormSingleSelect.tsx
@@ -52,6 +52,7 @@ export const FormSingleSelect: FC<FormSingleSelectProps> = ({
         {label && <label>{label}</label>}
         <div>
           <FieldTag
+            size="medium"
             content={field.value}
             name={field.value}
             key={field.value}

--- a/client/src/components/ui/LinkDisplayButton.tsx
+++ b/client/src/components/ui/LinkDisplayButton.tsx
@@ -9,8 +9,8 @@ interface LinkDisplayProps {
 }
 
 export const LinkDisplay: FC<LinkDisplayProps> = ({ href, ...rest }) => {
-  const hasLink = href === undefined || href === '';
-  return hasLink ? (
+  const missingLink = !href;
+  return missingLink ? (
     <p id="no-link">
       <Icon name="linkify" />
       Link not Provided

--- a/client/src/components/ui/LinkDisplayButton.tsx
+++ b/client/src/components/ui/LinkDisplayButton.tsx
@@ -9,7 +9,7 @@ interface LinkDisplayProps {
 }
 
 export const LinkDisplay: FC<LinkDisplayProps> = ({ href, ...rest }) => {
-  const hasLink = href === '';
+  const hasLink = href === undefined || href === '';
   return hasLink ? (
     <p id="no-link">
       <Icon name="linkify" />

--- a/client/src/pages/Pitch.scss
+++ b/client/src/pages/Pitch.scss
@@ -10,7 +10,8 @@
     display: flex;
     flex-direction: row;
     justify-content: space-between;
-    padding-top: 2rem;
+    padding-top: 1rem;
+    padding-bottom: 1rem;
 
     .form-content {
       display: flex;

--- a/client/src/utils/enums.ts
+++ b/client/src/utils/enums.ts
@@ -122,3 +122,27 @@ export const editStatusEnum = {
   DROPPED: 'Dropped',
   TRANSLATION_IP: 'Translation In Progress',
 };
+
+export const factCheckingStatusEnum = {
+  NEEDS_FC: 'Needs FC',
+  FC_IN_PROGRESS: 'FC In Progress',
+  FC_DONE: 'FC Done',
+  NOT_INTEGRATED: 'Not Integrated',
+  FC_INTEGRATED: 'FC Integrated',
+};
+
+export const visualStatusEnum = {
+  UNASSIGNED: 'Unassigned',
+  IN_PROGRESS: 'In Progress',
+  REUSE_ILLUSTRATION: 'Re-use Illustration',
+  IN_DRIVE: 'In Drive',
+  UNCERTAIN: 'Uncertain',
+};
+
+export const layoutStatusEnum = {
+  IN_PROGRESS: 'In Progress',
+  LAYOUT_DRAFTED: 'Layout Drafted',
+  COPY_PLACED: 'Copy Placed',
+  BOARD_PRINTED: 'Board Printed',
+  FINALIZED: 'Finalized',
+};

--- a/client/src/utils/enums.ts
+++ b/client/src/utils/enums.ts
@@ -135,8 +135,8 @@ export const visualStatusEnum = {
   UNASSIGNED: 'Unassigned',
   IN_PROGRESS: 'In Progress',
   REUSE_ILLUSTRATION: 'Re-use Illustration',
-  IN_DRIVE: 'In Drive',
   UNCERTAIN: 'Uncertain',
+  IN_DRIVE: 'In Drive',
 };
 
 export const layoutStatusEnum = {

--- a/common/index.d.ts
+++ b/common/index.d.ts
@@ -103,7 +103,9 @@ export interface IPitch {
   factCheckingLink: string;
   visualStatus: string;
   visualLink: string;
+  visualNotes: string;
   layoutStatus: string;
+  layoutNotes: string;
 }
 
 export interface IPitchAggregate extends IPitch {

--- a/common/index.d.ts
+++ b/common/index.d.ts
@@ -106,6 +106,7 @@ export interface IPitch {
   layoutNotes: string;
   wordCount: number;
   pageCount: number;
+  isInternal: boolean;
 }
 
 export interface IPitchAggregate extends IPitch {

--- a/common/index.d.ts
+++ b/common/index.d.ts
@@ -99,6 +99,11 @@ export interface IPitch {
   editStatus: string;
   wordCount: number;
   pageCount: number;
+  factCheckingStatus: string;
+  factCheckingLink: string;
+  visualStatus: string;
+  visualLink: string;
+  layoutStatus: string;
 }
 
 export interface IPitchAggregate extends IPitch {

--- a/common/index.d.ts
+++ b/common/index.d.ts
@@ -97,8 +97,6 @@ export interface IPitch {
   updatedAt: Date;
   issueStatuses: { issueId: string; issueStatus: string }[];
   editStatus: string;
-  wordCount: number;
-  pageCount: number;
   factCheckingStatus: string;
   factCheckingLink: string;
   visualStatus: string;
@@ -106,6 +104,8 @@ export interface IPitch {
   visualNotes: string;
   layoutStatus: string;
   layoutNotes: string;
+  wordCount: number;
+  pageCount: number;
 }
 
 export interface IPitchAggregate extends IPitch {

--- a/common/interfaces/pitch.interface.ts
+++ b/common/interfaces/pitch.interface.ts
@@ -37,7 +37,9 @@ export interface Pitch {
   factCheckingLink: string;
   visualStatus: string;
   visualLink: string;
+  visualNotes: string;
   layoutStatus: string;
+  layoutNotes: string;
   wordCount: number;
   pageCount: number;
 }

--- a/common/interfaces/pitch.interface.ts
+++ b/common/interfaces/pitch.interface.ts
@@ -33,6 +33,11 @@ export interface Pitch {
   updatedAt: Date;
   issueStatuses: { issueId: string; issueStatus: string, releaseDate: string }[];
   editStatus: string;
+  factCheckingStatus: string;
+  factCheckingLink: string;
+  visualStatus: string;
+  visualLink: string;
+  layoutStatus: string;
   wordCount: number;
   pageCount: number;
 }


### PR DESCRIPTION
## Summary 
Added the following new fields to `Pitch`: 
1. Visuals
   - `visualStatus`
   - `visualLink`
   - `visualNotes`
2. Layout
   - `layoutStatus`
   - `layoutNotes`
3. Fact Checking
   - `factCheckingStatus`
   - `factCheckingLin` 

## Changes
- Added new fields to `Pitch` model
- Added status to enum types
- Added new fields to Review Claim Form 
- Added status display to Kanban cards